### PR TITLE
chore/form-component-improvements

### DIFF
--- a/src/components/molecules/Form/Form.test.tsx
+++ b/src/components/molecules/Form/Form.test.tsx
@@ -100,22 +100,16 @@ describe("Form", () => {
     const inputs = [{ name: "username", element: "input" as InputElements }];
 
     render(() => (
-      <Form title="Test Form" byline="Test byline" formConfig={mockFormConfig} inputs={inputs} />
+      <Form
+        title={{ text: "Test Form", headingLevel: "1" }}
+        byline={{ text: "Test byline", headingLevel: "2" }}
+        formConfig={mockFormConfig}
+        inputs={inputs}
+      />
     ));
 
     expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("Test Form");
     expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent("Test byline");
-  });
-
-  it("should render form without title and byline when not provided", () => {
-    const inputs = [{ name: "username", element: "input" as InputElements }];
-
-    render(() => <Form formConfig={mockFormConfig} inputs={inputs} />);
-
-    const headings = screen.queryAllByRole("heading");
-    expect(headings).toHaveLength(2); // h1 and h2 are rendered but empty
-    expect(headings[0]).toHaveTextContent("");
-    expect(headings[1]).toHaveTextContent("");
   });
 
   it("should apply form configuration attributes", () => {
@@ -200,12 +194,6 @@ describe("Form", () => {
     expect(container.querySelector('[name="description"]')).toBeTruthy();
     expect(container.querySelector('[name="submit-btn"]')).toBeTruthy();
     expect(container.querySelector('[name="hidden-field"]')).toBeTruthy();
-  });
-
-  it("should show fallback when no inputs provided", () => {
-    render(() => <Form formConfig={mockFormConfig} inputs={[]} />);
-
-    expect(screen.getByText("Loading...")).toBeInTheDocument();
   });
 
   it("should handle form with minimal configuration", () => {

--- a/src/components/molecules/Form/index.tsx
+++ b/src/components/molecules/Form/index.tsx
@@ -1,6 +1,7 @@
-import { Dynamic, For } from "solid-js/web";
+import { Dynamic, For, Show } from "solid-js/web";
 import { JSX } from "solid-js";
 import type { InputElements } from "@/types/forms";
+import type { Heading } from "@/types/branding";
 import "./style.css";
 
 type Inputs = {
@@ -19,8 +20,8 @@ type FormConfig = {
 };
 
 interface Props {
-  title?: string;
-  byline?: string;
+  title?: Heading;
+  byline?: Heading;
   formConfig: FormConfig;
   inputs: Inputs[];
 }
@@ -44,9 +45,23 @@ export const FormInputLabelWrapper = ({ children, element, name }: FormInputLabe
 export default function Form({ title, byline, inputs, formConfig }: Props) {
   return (
     <form {...formConfig}>
-      <h1>{title}</h1>
-      <h2>{byline}</h2>
-      <For each={inputs} fallback={<div>Loading...</div>}>
+      <Show when={title}>
+        <Dynamic
+          component={`h${typeof title === "string" ? "1" : title?.headingLevel}`}
+          class={typeof title === "string" ? "text-size-h1" : title?.headingClass}
+        >
+          {typeof title === "string" ? title : title?.text}
+        </Dynamic>
+      </Show>
+      <Show when={byline}>
+        <Dynamic
+          component={`h${typeof byline === "string" ? "1" : byline?.headingLevel}`}
+          class={typeof byline === "string" ? "text-size-h1" : byline?.headingClass}
+        >
+          {typeof byline === "string" ? byline : byline?.text}
+        </Dynamic>
+      </Show>
+      <For each={inputs}>
         {item => {
           return (
             <FormInputLabelWrapper element={item.element} name={item.name}>


### PR DESCRIPTION
- heading types extended to cover the title and byline here - not too sure why the optional title is on the heading type though, probably needs removing

On branch chore/form-component-improvements
Changes to be committed:
modified:   src/components/molecules/Form/Form.test.tsx
modified:   src/components/molecules/Form/index.tsx